### PR TITLE
1.5 support

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -6,6 +6,7 @@
   <url>https://github.com/zed-0xff/RW-GeneCollectorQOL</url>
   <supportedVersions>
     <li>1.4</li>
+    <li>1.5</li>
   </supportedVersions>
   <description><![CDATA[<color=#1a8bff><b>Gene Collector QoL</b></color>
 

--- a/Source/GeneCollectorQOL.csproj
+++ b/Source/GeneCollectorQOL.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>zed.0xff.GeneCollectorQOL</RootNamespace>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <OutputPath>../Assemblies</OutputPath>
+    <OutputPath>../1.5/Assemblies</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Source/Patch_CompGenepackContainer.cs
+++ b/Source/Patch_CompGenepackContainer.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection.Emit;
 using System.Reflection;
 using System;
+using LudeonTK;
 using UnityEngine;
 using Verse;
 

--- a/Source/Patch_GeneUIUtility.cs
+++ b/Source/Patch_GeneUIUtility.cs
@@ -8,7 +8,7 @@ using System.Reflection;
 
 // draw yellow bg on genes in a combined genepack that we don't have as separate genes
 namespace zed_0xff.GeneCollectorQOL {
-    [HarmonyPatch(typeof(GeneUIUtility), "DrawGeneDef_NewTemp")]
+    [HarmonyPatch(typeof(GeneUIUtility), "DrawGeneDef")]
     static class Patch_Color
     {
         public static float sat => 0.5f;


### PR DESCRIPTION
Put an assembly built against 1.4 in `1.4/Assemblies`. The new build will go in `1.5/Assemblies`. Everything should then work for both versions.